### PR TITLE
Replace cpSync with copyFileSync

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -23,7 +23,7 @@ function main ({ csvPath, dbPath, outPath }) {
   const headers = data[0]
   const rows = data.slice(1)
 
-  fs.cpSync(dbPath, outPath)
+  fs.copyFileSync(dbPath, outPath)
   const db = sqlite(outPath)
 
   const errors = []


### PR DESCRIPTION
cpSync was added in nodejs 16.7 and is still experimental, also unnecessary since we're not copying directories here.